### PR TITLE
Fix max-rounds to use spec default of 5 instead of 1

### DIFF
--- a/arena.yaml
+++ b/arena.yaml
@@ -26,7 +26,7 @@ agents:
     enabled: true
 
 limits:
-  max-rounds: 1
+  max-rounds: 5
 
 tournament:
   min-agents: 1


### PR DESCRIPTION
## Summary
- Changes `max-rounds: 1` to `max-rounds: 5` in `arena.yaml`
- This aligns with the spec default which requires 5 cross-pollination rounds for agents to learn from each other

## Test plan
- [x] All tests pass (`mvn verify`)
- [x] Dry-run output shows 5 cross-pollination rounds

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Increased the maximum number of rounds allowed in the arena from 1 to 5, enabling more extensive tournament configurations and competitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->