### PR TITLE
chore: ignore Eclipse IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,10 @@ Thumbs.db
 
 # Environment files (contain secrets)
 .env
+/.classpath
+/.factorypath
+/.project
+/.settings/org.eclipse.core.resources.prefs
+/.settings/org.eclipse.jdt.apt.core.prefs
+/.settings/org.eclipse.jdt.core.prefs
+/.settings/org.eclipse.m2e.core.prefs


### PR DESCRIPTION
## Summary
- Add Eclipse IDE metadata files to `.gitignore` (`.classpath`, `.factorypath`, `.project`, and `.settings/*` prefs)

## Test plan
- [x] Verify Eclipse files no longer appear in `git status`