### PR TITLE
test: verify arena.yaml spawns claude subprocess with Opus 4.7

### DIFF
--- a/src/test/java/dev/reviewarena/agent/OpusModelIntegrationTest.java
+++ b/src/test/java/dev/reviewarena/agent/OpusModelIntegrationTest.java
@@ -1,0 +1,70 @@
+package dev.reviewarena.agent;
+
+import dev.reviewarena.config.AgentConfig;
+import dev.reviewarena.config.ArenaConfig;
+import dev.reviewarena.config.ConfigLoader;
+import dev.reviewarena.config.ConfigLoader.CliOverrides;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * End-to-end verification that the project's real arena.yaml produces subprocess
+ * commands pinned to Claude Opus 4.7.
+ *
+ * <p>Loads the actual arena.yaml from the repo root, runs it through the same
+ * ConfigLoader + CommandBuilder pipeline the runtime uses, and asserts the final
+ * argv list that would be passed to ProcessBuilder contains --model claude-opus-4-7.
+ */
+class OpusModelIntegrationTest {
+
+    private static final String EXPECTED_MODEL = "claude-opus-4-7";
+
+    @Test
+    void arenaYaml_claudeReviewAgent_spawnsWithOpus4_7() {
+        List<String> command = buildRealCommandFor("claude-1");
+
+        assertModelFlag(command);
+    }
+
+    @Test
+    void arenaYaml_synthesisAgent_spawnsWithOpus4_7() {
+        List<String> command = buildRealCommandFor("synthesis");
+
+        assertModelFlag(command);
+    }
+
+    private List<String> buildRealCommandFor(String agentName) {
+        Path projectRoot = Paths.get("").toAbsolutePath();
+        Path arenaYaml = projectRoot.resolve("arena.yaml");
+        assertTrue(arenaYaml.toFile().exists(),
+            "arena.yaml missing at " + arenaYaml);
+
+        ArenaConfig config = new ConfigLoader(projectRoot)
+            .load(arenaYaml, CliOverrides.none());
+
+        AgentConfig agent = config.agents().get(agentName);
+        assertNotNull(agent, "Agent '" + agentName + "' not found in loaded config");
+
+        return new CommandBuilder().build(
+            agent,
+            projectRoot.resolve("prompt.md"),
+            projectRoot.resolve("review.md")
+        );
+    }
+
+    private void assertModelFlag(List<String> command) {
+        int idx = command.indexOf("--model");
+        assertTrue(idx >= 0,
+            "Command missing --model flag. Full command: " + command);
+        assertTrue(idx + 1 < command.size(),
+            "--model flag has no value. Full command: " + command);
+        assertEquals(EXPECTED_MODEL, command.get(idx + 1),
+            "Expected model " + EXPECTED_MODEL + " but got " + command.get(idx + 1)
+                + ". Full command: " + command);
+    }
+}


### PR DESCRIPTION
## Summary
- New `OpusModelIntegrationTest` loads the real `arena.yaml` through the runtime `ConfigLoader` + `CommandBuilder` pipeline and asserts the final argv list passed to `ProcessBuilder` contains `--model claude-opus-4-7`.
- Covers both the review agent (`claude-1`) and the `synthesis` agent.
- Guards against accidental model downgrade when `arena.yaml` is edited.

## Test plan
- [x] `mvn test -Dtest=OpusModelIntegrationTest` — both tests pass
- [ ] Revert the model flag to `opus` in `arena.yaml` locally and confirm the test fails with a clear message