### PR TITLE
fix: prevent round 1+ timeouts on Opus 4.7 reviews

### DIFF
--- a/arena.yaml
+++ b/arena.yaml
@@ -14,6 +14,12 @@
 
 review-agents: claude, claude, claude
 
+timeouts:
+  # Cross-pollination rounds (1+) require agents to re-read all prior reviews,
+  # verify each claim, and produce a synthesized review. The default 10 min is
+  # only enough for Round 0; Opus 4.7 reliably exceeds it on Round 1+.
+  agent-timeout-ms: 1800000   # 30 minutes per agent
+
 agents:
   # Claude review agent: use Opus 4.7 model for highest-quality reviews
   claude:

--- a/src/main/resources/prompts/round-1.md
+++ b/src/main/resources/prompts/round-1.md
@@ -56,7 +56,6 @@ For **every issue** raised by competing reviewers:
 Use your tools actively:
 - Run `git diff` to see the actual changes
 - Read the relevant source files
-- Run existing tests (`mvn test`, `npm test`, etc.) to verify behavior
 - Grep for usages to understand impact
 - Check if "bugs" are actually handled elsewhere
 


### PR DESCRIPTION
## Summary
- Round 0 agents already burn 6-8 min of the 10 min per-agent timeout; Round 1+ agents do strictly more work (re-read every prior finding, verify each against the code, then produce a merged review) and reliably hit the timeout, causing the tournament to abort at the min-agents threshold.
- Raise `agent-timeout-ms` to 30 min in `arena.yaml` to match the real cost of cross-pollination rounds with Opus 4.7.
- Drop the `mvn test`/`npm test` instruction from `round-1.md` — running a full test suite per finding can consume the entire budget on larger projects with negligible review-signal gain over reading the code.

## Test plan
- [ ] Run `review-arena <commit>` against a non-trivial commit and confirm the tournament progresses past Round 1.
- [ ] Inspect `.arena/rounds/round-1/<agent>/review.md` files to confirm agents still produce complete reviews without the test-running step.
- [ ] Verify per-round durations in the log are within the new 30 min budget.