### PR TITLE
fix: raise default agent timeout so Round 1+ doesn't abort

### DIFF
--- a/arena.yaml
+++ b/arena.yaml
@@ -14,12 +14,6 @@
 
 review-agents: claude, claude, claude
 
-timeouts:
-  # Cross-pollination rounds (1+) require agents to re-read all prior reviews,
-  # verify each claim, and produce a synthesized review. The default 10 min is
-  # only enough for Round 0; Opus 4.7 reliably exceeds it on Round 1+.
-  agent-timeout-ms: 1800000   # 30 minutes per agent
-
 agents:
   # Claude review agent: use Opus 4.7 model for highest-quality reviews
   claude:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,8 +42,11 @@ execution:
   show-agent-output: true  # Stream agent output to console with prefixes
 
 timeouts:
-  agent-timeout-ms: 600000    # 10 minutes per agent
-  round-timeout-ms: 900000    # 15 minutes
+  # Cross-pollination rounds (1+) re-read every prior finding and verify each
+  # against the code. With Opus 4.7 this routinely exceeds 10 min; the old
+  # default timed out every Round 1 agent and aborted the tournament.
+  agent-timeout-ms: 1800000   # 30 minutes per agent
+  round-timeout-ms: 2700000   # 45 minutes (3 agents x 30 min with parallel execution)
   grace-period-ms: 5000       # 5 seconds
   on-timeout: kill-and-skip
   preserve-partial-output: false

--- a/src/test/java/dev/reviewarena/config/ArenaConfigTest.java
+++ b/src/test/java/dev/reviewarena/config/ArenaConfigTest.java
@@ -21,8 +21,8 @@ class ArenaConfigTest {
         assertEquals(500, config.maxOutputSizeKb());
         assertEquals(0, config.maxConcurrent());
         assertTrue(config.showAgentOutput());
-        assertEquals(600_000, config.agentTimeoutMs());
-        assertEquals(900_000, config.roundTimeoutMs());
+        assertEquals(1_800_000, config.agentTimeoutMs());
+        assertEquals(2_700_000, config.roundTimeoutMs());
         assertEquals(5_000, config.gracePeriodMs());
         assertEquals(1, config.minAgents()); // Changed from 2 to 1 for self-consistency
         assertEquals(Path.of(".arena"), config.outputDir());

--- a/src/test/java/dev/reviewarena/config/ConfigLoaderTest.java
+++ b/src/test/java/dev/reviewarena/config/ConfigLoaderTest.java
@@ -36,7 +36,7 @@ class ConfigLoaderTest {
         assertEquals(5, config.maxRounds());
         assertEquals(500, config.maxOutputSizeKb());
         assertEquals(0, config.maxConcurrent());
-        assertEquals(600_000, config.agentTimeoutMs());
+        assertEquals(1_800_000, config.agentTimeoutMs());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Follow-up to #123. That PR only bumped this repo's `arena.yaml`, which has no effect when `review-arena` runs from another project's cwd — the bundled `application.yaml` defaults win, and Round 1 agents still hit the 10 min timeout.
- Raise defaults to 30 min per agent / 45 min per round so Opus 4.7 cross-pollination rounds actually fit.
- Drop the now-redundant `arena.yaml` override; update the two tests that asserted the old defaults.

## Test plan
- [ ] `mvn test -Dtest=ArenaConfigTest,ConfigLoaderTest` — default-assertion tests pass.
- [ ] Run `review-arena <commit>` from a project *without* its own `arena.yaml` and confirm Round 1 completes within the new budget.
- [ ] Confirm the rebuilt jar (`target/review-arena-1.0-SNAPSHOT.jar`) picks up the new defaults.